### PR TITLE
improve: epochs from 1 -> max_epochs + 1

### DIFF
--- a/lantern/epochs.py
+++ b/lantern/epochs.py
@@ -1,5 +1,5 @@
 def Epochs(max_epochs):
     """Simple generator that prints the current epoch"""
-    for epoch in range(max_epochs):
-        print(f"------ epoch: {epoch + 1} / {max_epochs} ------")
+    for epoch in range(1, max_epochs + 1):
+        print(f"------ epoch: {epoch} / {max_epochs} ------")
         yield epoch


### PR DESCRIPTION
Personally I think this makes more sense. Right now when we log things to TB using `epoch` as step it's being logged as step 0, could also just set `epoch + 1` everywhere in the template but I think that's uglier.