### PR TITLE
improve: prettier metric table with mixed types

### DIFF
--- a/lantern/metric_table.py
+++ b/lantern/metric_table.py
@@ -36,7 +36,7 @@ class MetricTable(FunctionalBase):
                 f"{self.name}:",
                 textwrap.indent(
                     (
-                        pd.Series(self.compute()).to_string(
+                        pd.Series(self.compute(), dtype=object).to_string(
                             name=True, dtype=False, index=True
                         )
                     ),


### PR DESCRIPTION
Pandas coerces ints to floats if it gets a mix of those types in the same column which results in table formatting like this

```
evaluate_early_stopping:                                              
evaluate_early_stopping:                                              
  l1                               0.010323
  loss                             0.027584
  f1                               0.995977
  precision                        0.993579
  recall                           0.998387
  total_fastenings_example       620.000000
  total_fastenings_prediction    623.000000
```

Forcing it to `object` (basically any) type gives us this format instead
```
evaluate_early_stopping:                                              
  l1                             0.010323
  loss                           0.027584
  f1                             0.995977
  precision                      0.993579
  recall                         0.998387
  total_fastenings_example            620
  total_fastenings_prediction         623
```