### PR TITLE
fix: import issues in metric

### DIFF
--- a/lantern/metric.py
+++ b/lantern/metric.py
@@ -3,7 +3,8 @@ from typing import Any, Callable, List, Optional, Union
 
 import numpy as np
 
-from lantern import FunctionalBase, star
+from lantern.functional_base import FunctionalBase
+from lantern.star import star
 
 
 class MapMetric(FunctionalBase):


### PR DESCRIPTION
from wire damage:
```
Traceback (most recent call last):
  File "/home/aiwizo/Documents/trafikverket-wire-damage/.venv/.guild/runs/24ec3178dc0e45ebb4aba6166c75c006/.guild/sourcecode/operations/train_production.py", line 281, in <module>
    train(config)
  File "/home/aiwizo/Documents/trafikverket-wire-damage/.venv/.guild/runs/24ec3178dc0e45ebb4aba6166c75c006/.guild/sourcecode/operations/train_production.py", line 94, in train
    evaluate_metrics = {
  File "/home/aiwizo/Documents/trafikverket-wire-damage/.venv/.guild/runs/24ec3178dc0e45ebb4aba6166c75c006/.guild/sourcecode/operations/train_production.py", line 95, in <dictcomp>
    name: metrics.evaluate_metrics() for name in evaluate_data_loaders
  File "/home/aiwizo/Documents/trafikverket-wire-damage/.venv/.guild/runs/24ec3178dc0e45ebb4aba6166c75c006/.guild/sourcecode/wire_damage/metrics.py", line 28, in evaluate_metrics
    lantern.Metric()
  File "/home/aiwizo/Documents/trafikverket-wire-damage/.venv/lib/python3.8/site-packages/lantern/metric.py", line 142, in starmap
    return self.map(star(fn))
TypeError: 'module' object is not callable
```